### PR TITLE
Update Readme, make socketcan_bridge targets accessible by ros2 cmd line, declare 'can_device' parameter in nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Canopen implementation for ROS.
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 ([![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) for `socketcan_bridge`)
 
-The current develop branch is `melodic-devel`, it targets ROS `melodic`. Needs C++14 compiler.
+The current develop branch is `dashing-devel`, it targets ROS `dashing`. Needs C++14 compiler.
 The released version gets synced over to the distro branch for each release.

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -92,9 +92,7 @@ install(
     socketcan_to_topic_node
     topic_to_socketcan
     topic_to_socketcan_node
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+    DESTINATION lib/${PROJECT_NAME}
 )
 
 install(

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -26,6 +26,8 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("socketcan_bridge_node");
 
+  node->declare_parameter("can_device");
+
   std::string can_device;
   node->get_parameter_or<std::string>("can_device", can_device, "can0");
 

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -26,6 +26,8 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("socketcan_to_topic_node");
 
+  node->declare_parameter("can_device");
+
   std::string can_device;
   node->get_parameter_or<std::string>("can_device", can_device, "can0");
 

--- a/socketcan_bridge/src/topic_to_socketcan_node.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan_node.cpp
@@ -26,6 +26,8 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("topic_to_socketcan_node");
 
+  node->declare_parameter("can_device");
+
   std::string can_device;
   node->get_parameter_or<std::string>("can_device", can_device, "can0");
 


### PR DESCRIPTION
Hello,
First of all, thank you for your great work on porting ros_canopen on ros2. I am using ros_canopen melodic version and I am evaluating the migration to ROS 2.

I use mainly socketcan_bridge. I tested on my side , the socketcan_to_topic and tocpi_to_socketcan node from dashing-devel
The socketcan_brige targets were not found by ros2 run cmd line so I fixed the install destination in associated CMakelist.txt
Now I can start the node with:
ros2 run socketcan_bridge socketcan_to_topic_node

I also added the declaration of the "can_device' parameter in both nodes so it can be changed by param yaml files.
ros2 run socketcan_bridge socketcan_to_topic_node __params:=param.yaml

with param.yaml:
> socketcan_to_topic_node:
>  ros__parameters:
>    can_device: "can5"

I also replaced melodic by dashing in Readme

For my test I created a virtual can interface:
sudo modprobe vcan
sudo ip link add dev can5 type vcan
sudo ip link set up can5

Here the result:
ros2 run socketcan_bridge socketcan_to_topic_node __params:=param.yaml 
[INFO] [socketcan_to_topic_node]: Successfully connected to can5.



Best Regards,
Xavier.